### PR TITLE
Fixes bug 30469

### DIFF
--- a/html/Callbacks/RTIR/Elements/MakeClicky/Default
+++ b/html/Callbacks/RTIR/Elements/MakeClicky/Default
@@ -249,10 +249,10 @@ unless (ref $ARGS{cache} && defined ${$ARGS{cache}}) {
             return if $parent_args->{lookup_params};
 
             require Digest::SHA;
-            return $m->cache->get(Digest::SHA::sha512_base64($$content));
+            return $m->cache->get(Digest::SHA::sha512_base64(Encode::encode( "UTF-8", $$content)));
         } elsif ($type eq 'store') {
             require Digest::SHA;
-            $m->cache->set(Digest::SHA::sha512_base64($$content),
+            $m->cache->set(Digest::SHA::sha512_base64(Encode::encode( "UTF-8", $$content)),
                            $$content,
                            "6 hours");
         } else {


### PR DESCRIPTION
Calculate the SHA1 of the encoded $$content, to prevent Digest::SHA::sha512_base64 to croak with wide characters.

Similar to what's done for MD5  in https://github.com/bestpractical/rt/blob/80bcdcfdea2988329a49bc6823f54da5d304762c/lib/RT/User.pm#L1000
