### PR TITLE
Fix default owner change to Unchanged

### DIFF
--- a/html/RTIR/Update.html
+++ b/html/RTIR/Update.html
@@ -94,8 +94,7 @@
                 DefaultLabel => loc("[_1] (Unchanged)", $m->scomp(
                     '/Elements/ShowUser', User => $Ticket->OwnerObj
                 ) ),
-                Default      => $ARGS{'Owner'} || $Ticket->Owner
-                    || $session{'CurrentUser'}->id,
+                Default      => $ARGS{'Owner'},
             }
         },
         {   name => 'Worked',


### PR DESCRIPTION
Hi,

I was having an issue where I wanted tickets to be assigned to the currently logged in user on correspond however whenever the owner was assigned they would then get un-assigned.

My problem was because the correspond triggered the scrip then an owner change was triggered afterwards because the `Update.html` page was always assigning owner to `$Ticket->Owner` instead of remaining unchanged.

If the value is set to `''` then the owner is set to "Unchanged" however when it is set to `$Ticket->Owner` explicitly and it always takes precedence over the other options and always performs an owner update even when not warranted like in my case.

My thread on the forums is here. Thanks for any help.
https://forum.bestpractical.com/t/scrip-action-triggers-before-ownership-change/33422